### PR TITLE
Removing full collection query

### DIFF
--- a/lib/mongo/grid/fs_bucket.rb
+++ b/lib/mongo/grid/fs_bucket.rb
@@ -438,7 +438,7 @@ module Mongo
       end
 
       def ensure_indexes!
-        if files_collection.find({}, projection: { _id: 1 }).to_a.empty?
+        if files_collection.find({}).count == 0
           chunks_collection.indexes.create_one(FSBucket::CHUNKS_INDEX, :unique => true)
           files_collection.indexes.create_one(FSBucket::FILES_INDEX)
         end


### PR DESCRIPTION
Previously, this code was querying all IDs in the collection and storing them in an array. This is very inefficient and causes a long delay when inserting a file into `fs.files`, especially when the system is under a heavy load.
